### PR TITLE
feat: Implement clearAll API to wipe all storage with optional file d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.0
+
+### New Features
+* feat: Add `clearAll({bool includeFiles = true})` to wipe both key-value and file storage in one call
+* feat: Extend `clearNormal()` and `clearSecure()` with `includeFiles` (default `false`) to optionally delete underlying files and file metadata for the respective storage
+
+### Internal
+* refactor: Consolidate file-clearing logic into `clearAllFilesInBox(...)` with `@visibleForTesting` for easier testing
+* test: Add coverage for `clearAll`, and `includeFiles` behavior in `clearNormal` and `clearSecure`
+
 ## 2.0.0
 
 This release delivers a simpler, clearer API and improved performance characteristics. It replaces the BoxType/Either-based surface with intent-driven methods and exception-based error handling. File APIs are simplified to use your own keys instead of passing metadata around.

--- a/lib/src/interface/i_vault_storage.dart
+++ b/lib/src/interface/i_vault_storage.dart
@@ -39,12 +39,28 @@ abstract class IVaultStorage {
   Future<void> delete(String key);
 
   /// Clear all normal storage.
+  ///
+  /// When [includeFiles] is true, also deletes normal file metadata and the
+  /// underlying file contents.
   /// Throws [StorageError] if the operation fails.
-  Future<void> clearNormal();
+  Future<void> clearNormal({bool includeFiles = false});
 
   /// Clear all secure storage.
+  ///
+  /// When [includeFiles] is true, also deletes secure file metadata and the
+  /// underlying encrypted file contents.
   /// Throws [StorageError] if the operation fails.
-  Future<void> clearSecure();
+  Future<void> clearSecure({bool includeFiles = false});
+
+  /// Clear all storage in one call.
+  ///
+  /// When [includeFiles] is true (default), this clears:
+  /// - Normal and secure key-value boxes
+  /// - Normal and secure file metadata boxes, and deletes underlying files
+  ///
+  /// When [includeFiles] is false, only key-value data is cleared.
+  /// Throws [StorageError] if the operation fails.
+  Future<void> clearAll({bool includeFiles = true});
 
   /// List stored keys.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: vault_storage
 description: A package for secure key-value and file storage using Hive and
   flutter_secure_storage.
-version: 2.0.0
+version: 2.1.0
 repository: https://github.com/sgaabdu4/vault_storage
 
 environment:


### PR DESCRIPTION
## 2.1.0

### New Features
* feat: Add `clearAll({bool includeFiles = true})` to wipe both key-value and file storage in one call
* feat: Extend `clearNormal()` and `clearSecure()` with `includeFiles` (default `false`) to optionally delete underlying files and file metadata for the respective storage

### Internal
* refactor: Consolidate file-clearing logic into `clearAllFilesInBox(...)` with `@visibleForTesting` for easier testing
* test: Add coverage for `clearAll`, and `includeFiles` behavior in `clearNormal` and `clearSecure`