### PR TITLE
Feature/make web compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.1.1
+
+### Web compatibility and quality
+* fix: Remove `dart:isolate` from the public import graph and use `compute` from `flutter/foundation`, enabling web platform detection on pub.dev.
+* fix: Use conditional imports that default to web-safe stubs and import `dart:io` only behind `dart.library.io`.
+* chore: Add explicit `platforms:` section in `pubspec.yaml` to declare support for Android, iOS, Linux, macOS, Web, and Windows.
+* chore: Add IO stubs in web mocks to satisfy analyzer for conditional imports.
+* fix: Address analyzer warnings (avoid `await` on synchronous `containsKey`).
+
 ## 2.1.0
 
 ### New Features

--- a/lib/src/extensions/storage_extensions.dart
+++ b/lib/src/extensions/storage_extensions.dart
@@ -1,6 +1,4 @@
 import 'dart:convert';
-// ignore: unused_import
-import 'dart:isolate'; // Used by compute() for isolate operations
 
 import 'package:flutter/foundation.dart';
 import 'package:vault_storage/src/errors/file_errors.dart';

--- a/lib/src/mock/file_io_mock.dart
+++ b/lib/src/mock/file_io_mock.dart
@@ -25,4 +25,35 @@ class File {
   Future<void> delete() async {
     throw UnsupportedError('File operations are not supported on the web.');
   }
+
+  // Added to satisfy conditional usage on native platforms
+  IOSink openWrite() {
+    throw UnsupportedError('File operations are not supported on the web.');
+  }
+
+  Future<RandomAccessFile> open() async {
+    throw UnsupportedError('File operations are not supported on the web.');
+  }
+}
+
+/// Minimal stub of IOSink used in native-only code paths.
+class IOSink {
+  void add(List<int> data) {
+    throw UnsupportedError('File operations are not supported on the web.');
+  }
+
+  Future<void> close() async {
+    throw UnsupportedError('File operations are not supported on the web.');
+  }
+}
+
+/// Minimal stub of RandomAccessFile used in native-only code paths.
+class RandomAccessFile {
+  Future<Uint8List> read(int bytes) async {
+    throw UnsupportedError('File operations are not supported on the web.');
+  }
+
+  Future<void> close() async {
+    throw UnsupportedError('File operations are not supported on the web.');
+  }
 }

--- a/lib/src/storage/file_operations.dart
+++ b/lib/src/storage/file_operations.dart
@@ -1,11 +1,12 @@
-import 'dart:io'
-    if (dart.library.js_interop) 'package:vault_storage/src/mock/file_io_mock.dart';
+// Prefer web-safe default imports and gate native IO behind dart.library.io
+import 'package:vault_storage/src/mock/file_io_mock.dart'
+    if (dart.library.io) 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'dart:typed_data' show BytesBuilder, Uint8List;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
-import 'package:path_provider/path_provider.dart'
-    if (dart.library.js_interop) 'package:vault_storage/src/mock/path_provider_mock.dart';
+import 'package:vault_storage/src/mock/path_provider_mock.dart'
+    if (dart.library.io) 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 import 'package:vault_storage/src/storage/web_download_helper.dart'
     if (dart.library.io) 'package:vault_storage/src/mock/web_download_stub.dart';

--- a/lib/src/vault_storage_impl.dart
+++ b/lib/src/vault_storage_impl.dart
@@ -417,8 +417,8 @@ class VaultStorageImpl implements IVaultStorage {
 
     String? jsonString;
     if (box is LazyBox<dynamic>) {
-      // Handle lazy boxes (files) - asynchronous
-      if (!await box.containsKey(key)) return null;
+      // Handle lazy boxes (files) - asynchronous get, sync containsKey in Hive_ce
+      if (!box.containsKey(key)) return null;
       jsonString = await box.get(key) as String?;
     } else if (box is Box<dynamic>) {
       // Handle normal boxes (key-value) - synchronous access but async decode
@@ -465,7 +465,7 @@ class VaultStorageImpl implements IVaultStorage {
 
         String? jsonString;
         if (box is LazyBox<dynamic>) {
-          if (!await box.containsKey(key)) return null;
+          if (!box.containsKey(key)) return null;
           jsonString = await box.get(key) as String?;
         } else if (box is Box<dynamic>) {
           if (!box.containsKey(key)) return null;
@@ -487,7 +487,7 @@ class VaultStorageImpl implements IVaultStorage {
 
         String? jsonString;
         if (box is LazyBox<dynamic>) {
-          if (!await box.containsKey(key)) return null;
+          if (!box.containsKey(key)) return null;
           jsonString = await box.get(key) as String?;
         } else if (box is Box<dynamic>) {
           if (!box.containsKey(key)) return null;
@@ -509,7 +509,7 @@ class VaultStorageImpl implements IVaultStorage {
         if (normalBox != null) {
           String? normalJsonString;
           if (normalBox is LazyBox<dynamic>) {
-            if (await normalBox.containsKey(key)) {
+            if (normalBox.containsKey(key)) {
               normalJsonString = await normalBox.get(key) as String?;
             }
           } else if (normalBox is Box<dynamic>) {
@@ -533,7 +533,7 @@ class VaultStorageImpl implements IVaultStorage {
         if (secureBox != null) {
           String? secureJsonString;
           if (secureBox is LazyBox<dynamic>) {
-            if (await secureBox.containsKey(key)) {
+            if (secureBox.containsKey(key)) {
               secureJsonString = await secureBox.get(key) as String?;
             }
           } else if (secureBox is Box<dynamic>) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,15 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.29.0"
 
+# Explicit platform support declaration for pub.dev
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
+
 dependencies:
   cryptography_plus: ^2.7.1
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: vault_storage
 description: A package for secure key-value and file storage using Hive and
   flutter_secure_storage.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/sgaabdu4/vault_storage
 
 environment:


### PR DESCRIPTION
## 2.1.1

### Web compatibility and quality
* fix: Remove `dart:isolate` from the public import graph and use `compute` from `flutter/foundation`, enabling web platform detection on pub.dev.
* fix: Use conditional imports that default to web-safe stubs and import `dart:io` only behind `dart.library.io`.
* chore: Add explicit `platforms:` section in `pubspec.yaml` to declare support for Android, iOS, Linux, macOS, Web, and Windows.
* chore: Add IO stubs in web mocks to satisfy analyzer for conditional imports.
* fix: Address analyzer warnings (avoid `await` on synchronous `containsKey`).