### PR TITLE
fix: resolve typeId conflict in StoredValueAdapter with hive_ce_flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.1] - 2026-03-24
+### Bug Fixes
+- **Fixed `StoredValueAdapter` typeId conflict with `hive_ce_flutter`** — Changed `StoredValueAdapter.typeId` from `200` to `220`. `hive_ce_flutter` v2.3.4's `ColorAdapter` defaults to typeId `200`, which caused `Hive.initFlutter()` (called internally by vault_storage) to register `ColorAdapter` at typeId 200 first. The subsequent `_registerAdapters()` guard (`Hive.isAdapterRegistered(200)`) then found the slot taken and silently skipped registering `StoredValueAdapter`. Any write using the v4 TypeAdapter format would crash with `HiveError: Cannot write, unknown type: StoredValue`. Since v4.0.0 had this bug from day one, no existing data was ever written in v4 TypeAdapter format — the typeId change is safe for all upgrading users.
+
 ## [4.0.0] - 2026-02-27
 ### Breaking changes
 - **Binary TypeAdapter storage** — All key-value writes now use a custom Hive TypeAdapter for `StoredValue` (typeId 200) instead of the previous `Map<String, dynamic>` wrapper. Per-entry overhead drops from ~36 bytes to 2 bytes and one fewer Map allocation per read/write.

--- a/lib/src/storage/stored_value_adapter.dart
+++ b/lib/src/storage/stored_value_adapter.dart
@@ -16,7 +16,7 @@ import 'package:vault_storage/src/storage/storage_strategy.dart';
 /// been written is **not supported**.
 class StoredValueAdapter extends TypeAdapter<StoredValue> {
   @override
-  final int typeId = 200;
+  final int typeId = 220;
 
   @override
   StoredValue read(BinaryReader reader) {

--- a/lib/src/vault_storage_impl.dart
+++ b/lib/src/vault_storage_impl.dart
@@ -93,8 +93,8 @@ class VaultStorageImpl implements IVaultStorage {
       await openBoxes(key);
 
       // Open custom boxes if provided
-      if (_customBoxConfigs != null && _customBoxConfigs!.isNotEmpty) {
-        await _openCustomBoxes(_customBoxConfigs!, key);
+      if (_customBoxConfigs != null && _customBoxConfigs.isNotEmpty) {
+        await _openCustomBoxes(_customBoxConfigs, key);
       }
 
       isVaultStorageReady = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: vault_storage
 description: A package for secure key-value and file storage using Hive and
   flutter_secure_storage.
-version: 4.0.0
+version: 4.0.1
 repository: https://github.com/sgaabdu4/vault_storage
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.5.0 <4.0.0"
   flutter: ">=3.29.0"
 
 # Explicit platform support declaration for pub.dev
@@ -18,11 +18,11 @@ platforms:
   windows:
 
 dependencies:
-  cryptography_plus: ^2.7.1
+  cryptography_plus: ^3.0.0
   flutter:
     sdk: flutter
   flutter_secure_storage: ^10.0.0
-  freerasp: ^7.4.0
+  freerasp: ^7.5.0
   freezed_annotation: ^3.1.0
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
@@ -32,7 +32,7 @@ dependencies:
   web: ^1.1.1
 
 dev_dependencies:
-  build_runner: ^2.11.1
+  build_runner: ^2.13.1
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/test/src/storage/stored_value_adapter_test.dart
+++ b/test/src/storage/stored_value_adapter_test.dart
@@ -15,8 +15,8 @@ void main() {
       adapter = StoredValueAdapter();
     });
 
-    test('typeId should be 200', () {
-      expect(adapter.typeId, equals(200));
+    test('typeId should be 220', () {
+      expect(adapter.typeId, equals(220));
     });
 
     test('should round-trip a native string value', () {
@@ -123,10 +123,7 @@ void main() {
       writer.write('value');
       final bytes = writer.toBytes();
 
-      expect(
-        () => _deserializeAdapter(adapter, bytes),
-        throwsA(isA<RangeError>()),
-      );
+      expect(() => _deserializeAdapter(adapter, bytes), throwsA(isA<RangeError>()));
     });
   });
 }


### PR DESCRIPTION
- **Fixed `StoredValueAdapter` typeId conflict with `hive_ce_flutter`** — Changed `StoredValueAdapter.typeId` from `200` to `220`. `hive_ce_flutter` v2.3.4's `ColorAdapter` defaults to typeId `200`, which caused `Hive.initFlutter()` (called internally by vault_storage) to register `ColorAdapter` at typeId 200 first. The subsequent `_registerAdapters()` guard (`Hive.isAdapterRegistered(200)`) then found the slot taken and silently skipped registering `StoredValueAdapter`. Any write using the v4 TypeAdapter format would crash with `HiveError: Cannot write, unknown type: StoredValue`. Since v4.0.0 had this bug from day one, no existing data was ever written in v4 TypeAdapter format — the typeId change is safe for all upgrading users.