### PR TITLE
feat: add internal adapter registration and update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ example/analysis_options.yaml
 example/pubspec.lock
 example/README.md
 
+.codebase-memory/*
+docs/*
+.github/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.2] - 2026-05-27
+### Maintenance
+- **Internal adapter registration** — `VaultStorage.create()` now registers vault_storage's Hive adapters synchronously, keeping Hive and adapter internals behind `package:vault_storage/vault_storage.dart`.
+- **Dependency updates** — Updated `flutter_secure_storage`, `freerasp`, `json_annotation`, `build_runner`, and `mocktail` to their latest compatible versions.
+- **Code generation refresh** — Regenerated Freezed output with the updated generator toolchain.
+
 ## [4.0.1] - 2026-03-24
 ### Bug Fixes
 - **Fixed `StoredValueAdapter` typeId conflict with `hive_ce_flutter`** — Changed `StoredValueAdapter.typeId` from `200` to `220`. `hive_ce_flutter` v2.3.4's `ColorAdapter` defaults to typeId `200`, which caused `Hive.initFlutter()` (called internally by vault_storage) to register `ColorAdapter` at typeId 200 first. The subsequent `_registerAdapters()` guard (`Hive.isAdapterRegistered(200)`) then found the slot taken and silently skipped registering `StoredValueAdapter`. Any write using the v4 TypeAdapter format would crash with `HiveError: Cannot write, unknown type: StoredValue`. Since v4.0.0 had this bug from day one, no existing data was ever written in v4 TypeAdapter format — the typeId change is safe for all upgrading users.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Add to your `pubspec.yaml`:
 ```yaml
 dependencies:
   # ... other dependencies
-  vault_storage: ^4.0.0 # Replace with the latest version
+  vault_storage: ^4.0.2 # Replace with the latest version
 ```
 
 Then run:
@@ -365,7 +365,10 @@ final secureOnly = await storage.get<String>('api_key', isSecure: true);
 final normalOnly = await storage.get<String>('theme', isSecure: false);
 ```
 
-The factory returns `IVaultStorage`, hiding implementation details.
+The factory returns `IVaultStorage`, hiding implementation details. App code
+should not import `package:hive_ce/hive.dart` or any `package:vault_storage/src/...`
+files for vault_storage internals; `VaultStorage.create()` and `init()` own
+adapter registration and box setup.
 
 ### Custom Boxes (v2.3.0+)
 

--- a/lib/src/entities/box_config.dart
+++ b/lib/src/entities/box_config.dart
@@ -19,7 +19,7 @@ part 'box_config.freezed.dart';
 /// );
 /// ```
 @freezed
-class BoxConfig with _$BoxConfig {
+abstract class BoxConfig with _$BoxConfig {
   const factory BoxConfig({
     /// The unique name of the box.
     required String name,

--- a/lib/src/entities/box_config.freezed.dart
+++ b/lib/src/entities/box_config.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,88 +9,63 @@ part of 'box_config.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$BoxConfig {
   /// The unique name of the box.
-  String get name => throw _privateConstructorUsedError;
+  String get name;
 
   /// Whether the box should be encrypted.
   /// When true, uses AES-GCM encryption with the master key.
-  bool get encrypted => throw _privateConstructorUsedError;
+  bool get encrypted;
 
   /// Whether to use lazy loading for this box.
   /// Lazy boxes load values on-demand, which is better for large data or files.
   /// Regular boxes load all keys into memory on open for faster access.
-  bool get lazy => throw _privateConstructorUsedError;
+  bool get lazy;
 
   /// Create a copy of BoxConfig
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $BoxConfigCopyWith<BoxConfig> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $BoxConfigCopyWith<$Res> {
-  factory $BoxConfigCopyWith(BoxConfig value, $Res Function(BoxConfig) then) =
-      _$BoxConfigCopyWithImpl<$Res, BoxConfig>;
-  @useResult
-  $Res call({String name, bool encrypted, bool lazy});
-}
-
-/// @nodoc
-class _$BoxConfigCopyWithImpl<$Res, $Val extends BoxConfig> implements $BoxConfigCopyWith<$Res> {
-  _$BoxConfigCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of BoxConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $BoxConfigCopyWith<BoxConfig> get copyWith =>
+      _$BoxConfigCopyWithImpl<BoxConfig>(this as BoxConfig, _$identity);
+
   @override
-  $Res call({
-    Object? name = null,
-    Object? encrypted = null,
-    Object? lazy = null,
-  }) {
-    return _then(_value.copyWith(
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      encrypted: null == encrypted
-          ? _value.encrypted
-          : encrypted // ignore: cast_nullable_to_non_nullable
-              as bool,
-      lazy: null == lazy
-          ? _value.lazy
-          : lazy // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is BoxConfig &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.encrypted, encrypted) || other.encrypted == encrypted) &&
+            (identical(other.lazy, lazy) || other.lazy == lazy));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name, encrypted, lazy);
+
+  @override
+  String toString() {
+    return 'BoxConfig(name: $name, encrypted: $encrypted, lazy: $lazy)';
   }
 }
 
 /// @nodoc
-abstract class _$$BoxConfigImplCopyWith<$Res> implements $BoxConfigCopyWith<$Res> {
-  factory _$$BoxConfigImplCopyWith(_$BoxConfigImpl value, $Res Function(_$BoxConfigImpl) then) =
-      __$$BoxConfigImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $BoxConfigCopyWith<$Res> {
+  factory $BoxConfigCopyWith(BoxConfig value, $Res Function(BoxConfig) _then) =
+      _$BoxConfigCopyWithImpl;
   @useResult
   $Res call({String name, bool encrypted, bool lazy});
 }
 
 /// @nodoc
-class __$$BoxConfigImplCopyWithImpl<$Res> extends _$BoxConfigCopyWithImpl<$Res, _$BoxConfigImpl>
-    implements _$$BoxConfigImplCopyWith<$Res> {
-  __$$BoxConfigImplCopyWithImpl(_$BoxConfigImpl _value, $Res Function(_$BoxConfigImpl) _then)
-      : super(_value, _then);
+class _$BoxConfigCopyWithImpl<$Res> implements $BoxConfigCopyWith<$Res> {
+  _$BoxConfigCopyWithImpl(this._self, this._then);
+
+  final BoxConfig _self;
+  final $Res Function(BoxConfig) _then;
 
   /// Create a copy of BoxConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -101,27 +76,184 @@ class __$$BoxConfigImplCopyWithImpl<$Res> extends _$BoxConfigCopyWithImpl<$Res, 
     Object? encrypted = null,
     Object? lazy = null,
   }) {
-    return _then(_$BoxConfigImpl(
+    return _then(_self.copyWith(
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       encrypted: null == encrypted
-          ? _value.encrypted
+          ? _self.encrypted
           : encrypted // ignore: cast_nullable_to_non_nullable
               as bool,
       lazy: null == lazy
-          ? _value.lazy
+          ? _self.lazy
           : lazy // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }
 }
 
+/// Adds pattern-matching-related methods to [BoxConfig].
+extension BoxConfigPatterns on BoxConfig {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_BoxConfig value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _BoxConfig() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_BoxConfig value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BoxConfig():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_BoxConfig value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BoxConfig() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String name, bool encrypted, bool lazy)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _BoxConfig() when $default != null:
+        return $default(_that.name, _that.encrypted, _that.lazy);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String name, bool encrypted, bool lazy) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BoxConfig():
+        return $default(_that.name, _that.encrypted, _that.lazy);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String name, bool encrypted, bool lazy)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BoxConfig() when $default != null:
+        return $default(_that.name, _that.encrypted, _that.lazy);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
-class _$BoxConfigImpl implements _BoxConfig {
-  const _$BoxConfigImpl({required this.name, this.encrypted = false, this.lazy = false});
+class _BoxConfig implements BoxConfig {
+  const _BoxConfig({required this.name, this.encrypted = false, this.lazy = false});
 
   /// The unique name of the box.
   @override
@@ -140,16 +272,19 @@ class _$BoxConfigImpl implements _BoxConfig {
   @JsonKey()
   final bool lazy;
 
+  /// Create a copy of BoxConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'BoxConfig(name: $name, encrypted: $encrypted, lazy: $lazy)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$BoxConfigCopyWith<_BoxConfig> get copyWith =>
+      __$BoxConfigCopyWithImpl<_BoxConfig>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BoxConfigImpl &&
+            other is _BoxConfig &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.encrypted, encrypted) || other.encrypted == encrypted) &&
             (identical(other.lazy, lazy) || other.lazy == lazy));
@@ -158,37 +293,52 @@ class _$BoxConfigImpl implements _BoxConfig {
   @override
   int get hashCode => Object.hash(runtimeType, name, encrypted, lazy);
 
+  @override
+  String toString() {
+    return 'BoxConfig(name: $name, encrypted: $encrypted, lazy: $lazy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$BoxConfigCopyWith<$Res> implements $BoxConfigCopyWith<$Res> {
+  factory _$BoxConfigCopyWith(_BoxConfig value, $Res Function(_BoxConfig) _then) =
+      __$BoxConfigCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String name, bool encrypted, bool lazy});
+}
+
+/// @nodoc
+class __$BoxConfigCopyWithImpl<$Res> implements _$BoxConfigCopyWith<$Res> {
+  __$BoxConfigCopyWithImpl(this._self, this._then);
+
+  final _BoxConfig _self;
+  final $Res Function(_BoxConfig) _then;
+
   /// Create a copy of BoxConfig
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$BoxConfigImplCopyWith<_$BoxConfigImpl> get copyWith =>
-      __$$BoxConfigImplCopyWithImpl<_$BoxConfigImpl>(this, _$identity);
+  $Res call({
+    Object? name = null,
+    Object? encrypted = null,
+    Object? lazy = null,
+  }) {
+    return _then(_BoxConfig(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      encrypted: null == encrypted
+          ? _self.encrypted
+          : encrypted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      lazy: null == lazy
+          ? _self.lazy
+          : lazy // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
 
-abstract class _BoxConfig implements BoxConfig {
-  const factory _BoxConfig({required final String name, final bool encrypted, final bool lazy}) =
-      _$BoxConfigImpl;
-
-  /// The unique name of the box.
-  @override
-  String get name;
-
-  /// Whether the box should be encrypted.
-  /// When true, uses AES-GCM encryption with the master key.
-  @override
-  bool get encrypted;
-
-  /// Whether to use lazy loading for this box.
-  /// Lazy boxes load values on-demand, which is better for large data or files.
-  /// Regular boxes load all keys into memory on open for faster access.
-  @override
-  bool get lazy;
-
-  /// Create a copy of BoxConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$BoxConfigImplCopyWith<_$BoxConfigImpl> get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/storage/stored_value_adapter.dart
+++ b/lib/src/storage/stored_value_adapter.dart
@@ -15,8 +15,10 @@ import 'package:vault_storage/src/storage/storage_strategy.dart';
 /// writes use this adapter. Downgrading from v4.x to v3.x after new data has
 /// been written is **not supported**.
 class StoredValueAdapter extends TypeAdapter<StoredValue> {
+  static const int storedValueTypeId = 220;
+
   @override
-  final int typeId = 220;
+  final int typeId = storedValueTypeId;
 
   @override
   StoredValue read(BinaryReader reader) {

--- a/lib/src/storage/vault_storage_adapter_registry.dart
+++ b/lib/src/storage/vault_storage_adapter_registry.dart
@@ -1,0 +1,12 @@
+import 'package:hive_ce/hive_ce.dart';
+import 'package:vault_storage/src/storage/stored_value_adapter.dart';
+
+/// Registers Hive adapters owned by vault_storage.
+abstract final class VaultStorageAdapterRegistry {
+  static void ensureRegistered() {
+    final adapter = StoredValueAdapter();
+    if (!Hive.isAdapterRegistered(adapter.typeId)) {
+      Hive.registerAdapter(adapter);
+    }
+  }
+}

--- a/lib/src/vault_storage_impl.dart
+++ b/lib/src/vault_storage_impl.dart
@@ -16,7 +16,7 @@ import 'package:vault_storage/src/security/security_exceptions.dart';
 import 'package:vault_storage/src/security/vault_security_config.dart';
 import 'package:vault_storage/src/storage/file_operations.dart';
 import 'package:vault_storage/src/storage/storage_strategy.dart';
-import 'package:vault_storage/src/storage/stored_value_adapter.dart';
+import 'package:vault_storage/src/storage/vault_storage_adapter_registry.dart';
 
 /// Simple, secure storage implementation for Flutter apps.
 ///
@@ -57,7 +57,9 @@ class VaultStorageImpl implements IVaultStorage {
         _fileOperations = fileOperations ?? FileOperations(),
         _securityConfig = securityConfig,
         _customBoxConfigs = customBoxes,
-        _storageDirectory = storageDirectory;
+        _storageDirectory = storageDirectory {
+    _registerAdapters();
+  }
 
   @override
   Future<void> init() {
@@ -81,8 +83,9 @@ class VaultStorageImpl implements IVaultStorage {
           // Log that security features are not available on this platform
           if (_securityConfig?.enableLogging == true) {
             debugPrint(
-                'VaultStorage: FreeRASP security features are only available on Android and iOS. '
-                'Current platform: ${defaultTargetPlatform.name}');
+              'VaultStorage: FreeRASP security features are only available on Android and iOS. '
+              'Current platform: ${defaultTargetPlatform.name}',
+            );
           }
         }
       }
@@ -305,10 +308,7 @@ class VaultStorageImpl implements IVaultStorage {
 
     try {
       // 1) Clear key-value stores
-      await Future.wait<void>([
-        boxes[BoxType.normal]!.clear(),
-        boxes[BoxType.secure]!.clear(),
-      ]);
+      await Future.wait<void>([boxes[BoxType.normal]!.clear(), boxes[BoxType.secure]!.clear()]);
 
       // 2) Always clear custom boxes (they hold key-value data)
       for (final box in customBoxes.values) {
@@ -540,10 +540,7 @@ class VaultStorageImpl implements IVaultStorage {
           );
         } else {
           return await _fileOperations.getNormalFile(
-            fileMetadata: metadata,
-            isWeb: kIsWeb,
-            getBox: getInternalBox,
-          );
+              fileMetadata: metadata, isWeb: kIsWeb, getBox: getInternalBox);
         }
       }
 
@@ -641,10 +638,7 @@ class VaultStorageImpl implements IVaultStorage {
       // Delete underlying file data first (avoid orphaned content/keys)
       if (normalMetadata != null) {
         await _fileOperations.deleteNormalFile(
-          fileMetadata: normalMetadata,
-          isWeb: kIsWeb,
-          getBox: getInternalBox,
-        );
+            fileMetadata: normalMetadata, isWeb: kIsWeb, getBox: getInternalBox);
       }
 
       if (secureMetadata != null) {
@@ -794,7 +788,7 @@ class VaultStorageImpl implements IVaultStorage {
     // Hive deserializes Maps as Map<dynamic, dynamic>; coerce to Map<String, dynamic>
     if (value is Map) {
       final coerced = <String, dynamic>{
-        for (final entry in value.entries) entry.key.toString(): entry.value,
+        for (final entry in value.entries) entry.key.toString(): entry.value
       };
       if (coerced is T) return coerced as T;
     }
@@ -835,10 +829,7 @@ class VaultStorageImpl implements IVaultStorage {
   /// Guards each registration with [isAdapterRegistered] so it is safe to call
   /// multiple times (e.g., in tests that re-initialise storage).
   void _registerAdapters() {
-    final adapter = StoredValueAdapter();
-    if (!Hive.isAdapterRegistered(adapter.typeId)) {
-      Hive.registerAdapter(adapter);
-    }
+    VaultStorageAdapterRegistry.ensureRegistered();
   }
 
   /// Get file metadata with optional storage type specification
@@ -904,10 +895,7 @@ class VaultStorageImpl implements IVaultStorage {
           );
         } else {
           await _fileOperations.deleteNormalFile(
-            fileMetadata: metadata,
-            isWeb: kIsWeb,
-            getBox: getInternalBox,
-          );
+              fileMetadata: metadata, isWeb: kIsWeb, getBox: getInternalBox);
         }
       } catch (_) {
         // Ignore per-file errors; final clear() will drop metadata
@@ -943,10 +931,7 @@ class VaultStorageImpl implements IVaultStorage {
         signingCertHashes: signingCertHashes ?? [],
         supportedStores: ['com.android.vending'], // Google Play Store
       ),
-      iosConfig: IOSConfig(
-        bundleIds: bundleId != null ? [bundleId] : [],
-        teamId: teamId ?? '',
-      ),
+      iosConfig: IOSConfig(bundleIds: bundleId != null ? [bundleId] : [], teamId: teamId ?? ''),
       watcherMail: config.watcherMail ?? '',
       isProd: config.isProd,
     );
@@ -1001,9 +986,7 @@ class VaultStorageImpl implements IVaultStorage {
           config.blockOnEmulator ||
           config.blockOnUnofficialStore) {
         throw const SecurityThreatException(
-          'Environment',
-          'Vault operations blocked due to detected security threats',
-        );
+            'Environment', 'Vault operations blocked due to detected security threats');
       }
     }
   }
@@ -1296,8 +1279,7 @@ class VaultStorageImpl implements IVaultStorage {
     for (final config in configs) {
       if (reservedNames.contains(config.name)) {
         throw VaultStorageInitializationError(
-          'Custom box name "${config.name}" conflicts with a reserved box name',
-        );
+            'Custom box name "${config.name}" conflicts with a reserved box name');
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: vault_storage
 description: A package for secure key-value and file storage using Hive and
   flutter_secure_storage.
-version: 4.0.1
+version: 4.0.2
 repository: https://github.com/sgaabdu4/vault_storage
 
 environment:
@@ -21,20 +21,20 @@ dependencies:
   cryptography_plus: ^3.0.0
   flutter:
     sdk: flutter
-  flutter_secure_storage: ^10.0.0
-  freerasp: ^7.5.0
+  flutter_secure_storage: ^10.3.0
+  freerasp: ^7.5.1
   freezed_annotation: ^3.1.0
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
   path_provider: ^2.1.5
   uuid: ^4.5.3
   web: ^1.1.1
 
 dev_dependencies:
-  build_runner: ^2.13.1
+  build_runner: ^2.15.0
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
   freezed: ^3.2.5
-  mocktail: ^1.0.4
+  mocktail: ^1.0.5

--- a/test/performance/list_storage_performance_design.md
+++ b/test/performance/list_storage_performance_design.md
@@ -1,0 +1,111 @@
+# List Storage Performance Test Design
+
+## Test Objectives
+
+Validate the performance optimization approach by measuring:
+1. Current performance with JSON string serialization
+2. Expected performance with native Hive storage
+3. Comparison across different data sizes
+
+## Test Scenarios
+
+### Scenario 1: Small Lists (10 items)
+```dart
+final milestones = List.generate(10, (i) => {
+  'id': i,
+  'title': 'Milestone $i',
+  'description': 'Description for milestone $i',
+  'completed': i % 2 == 0,
+  'createdAt': DateTime.now().toIso8601String(),
+});
+```
+
+### Scenario 2: Medium Lists (40 items) - USER'S CASE
+```dart
+final milestones = List.generate(40, (i) => {
+  'id': i,
+  'title': 'Milestone $i',
+  'description': 'Description for milestone $i with some additional text',
+  'priority': ['low', 'medium', 'high'][i % 3],
+  'tags': ['tag${i % 5}', 'tag${i % 7}'],
+  'metadata': {
+    'createdBy': 'user_${i % 10}',
+    'lastModified': DateTime.now().toIso8601String(),
+    'version': i % 5,
+  },
+  'completed': i % 2 == 0,
+});
+```
+
+### Scenario 3: Large Lists (100 items)
+```dart
+final milestones = List.generate(100, (i) => {
+  // Same structure as Scenario 2
+});
+```
+
+### Scenario 4: Very Large Lists (1000 items)
+```dart
+final milestones = List.generate(1000, (i) => {
+  // Same structure as Scenario 2
+});
+```
+
+## Measurements
+
+For each scenario, measure:
+- Write time (ms)
+- Read time (ms)
+- Storage size (bytes)
+- Memory usage (MB)
+
+## Expected Results
+
+### Current Implementation (JSON String)
+| Items | Write (ms) | Read (ms) | Notes |
+|-------|-----------|----------|-------|
+| 10    | ~200      | ~150     | Small overhead |
+| 40    | ~800      | ~1000    | USER'S ISSUE |
+| 100   | ~2000     | ~2500    | Very slow |
+| 1000  | ~20000    | ~25000   | Unusable |
+
+### Optimized Implementation (Native Hive)
+| Items | Write (ms) | Read (ms) | Notes |
+|-------|-----------|----------|-------|
+| 10    | ~5        | ~3       | Instant |
+| 40    | ~20       | ~15      | 50x faster! |
+| 100   | ~50       | ~40      | Still fast |
+| 1000  | ~200      | ~150     | Acceptable |
+
+## Performance Target
+
+**For 40-item list (user's case)**:
+- Current: 1055ms read
+- Target: <50ms read
+- Improvement: >20x faster
+
+## Test Implementation Notes
+
+1. Use `Stopwatch` for precise timing
+2. Run each test 10 times and average results
+3. Include warmup runs to eliminate JIT effects
+4. Measure both normal and secure storage
+5. Test on real device (not just simulator)
+
+## Key Insight
+
+The bottleneck is NOT Hive CE - it's our unnecessary JSON serialization layer!
+
+**Current Flow:**
+```
+Dart List → jsonEncode → String → Hive → String → jsonDecode → Dart List
+         ⬆ SLOW (400ms)                        ⬆ SLOW (400ms)
+```
+
+**Optimized Flow:**
+```
+Dart List → Hive Binary Format → Dart List
+         ⬆ FAST (10ms)    ⬆ FAST (5ms)
+```
+
+Hive CE already has efficient binary serialization for Lists and Maps!

--- a/test/vault_storage_test.dart
+++ b/test/vault_storage_test.dart
@@ -1,8 +1,17 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive_ce.dart';
+import 'package:vault_storage/src/storage/stored_value_adapter.dart';
 import 'package:vault_storage/vault_storage.dart';
 
 void main() {
   group('VaultStorage Factory', () {
+    test('should register internal Hive adapters when creating storage', () {
+      final storage = VaultStorage.create();
+
+      expect(storage, isA<IVaultStorage>());
+      expect(Hive.isAdapterRegistered(StoredValueAdapter.storedValueTypeId), isTrue);
+    });
+
     test('should create instance without security config', () {
       final storage = VaultStorage.create();
       expect(storage, isNotNull);


### PR DESCRIPTION
- Implemented `VaultStorageAdapterRegistry` for registering Hive adapters.
- Updated `VaultStorage.create()` to register adapters synchronously.
- Updated dependencies: flutter_secure_storage, freerasp, json_annotation, build_runner, mocktail.
- Regenerated Freezed output with the updated generator toolchain.
- Added performance test design for storage optimization.